### PR TITLE
Fix “controlled component” behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Options should be provided as an `Array` of `Object`s, each with a `value` and `
 
 The `value` property of each option should be set to either a string or a number.
 
-When the value is changed, `onChange(selectedValueOrValues)` will fire.
+When the value is changed, `onChange(selectedValueOrValues)` will fire, allowing you to re-render with an updated `value=` prop.
 
 ```javascript
 var CheckedSelect = require('react-select-checked');
@@ -36,15 +36,16 @@ var options = [
     {label: 'Caramel', value: 'caramel'},
 ];
 
-var initialValue = [{label: 'Caramel', value: 'caramel'}];
+var currentSelection = [{label: 'Caramel', value: 'caramel'}];
 
 function logChange(val) {
   console.log('Selected value: ', val);
+  setState({currentSelection: val});
 }
 
 <CheckedSelect
   name="form-field-name"
-  value={initialValue}
+  value={currentSelection}
   options={options}
   onChange={logChange}
 />
@@ -61,6 +62,7 @@ When your async process finishes getting the options, pass them to `callback(err
 ```javascript
 function logChange(val) {
   console.log('Selected value: ', val);
+  setState({value: val});
 }
 
 function getOptions (input, callback) {
@@ -93,6 +95,7 @@ loadOptions supports Promises, which can be used in very much the same way as ca
 ```javascript
 function logChange(val) {
   console.log('Selected value: ', val);
+  setState({value: val});
 }
 
 function getGitHubUsers(input) {

--- a/lib/elements/CheckedSelect.js
+++ b/lib/elements/CheckedSelect.js
@@ -89,16 +89,16 @@ class CheckedSelect extends React.Component {
         return this._visibleOptions;
     }
 
-    componentDidUpdate(prevProps) {
-        if (this.props.value !== prevProps.value) {
+    componentWillReceiveProps(nextProps) {
+        if (this.props.value !== nextProps.value) {
             // do below only if value changed
-            let valueArray  = this.props.value.map( val => val.value);
+            let valueStrings  = nextProps.value.map(val => val.value);
             // clear all
             this.clearAllOptionsIsSelectedFlags();
             // update the flag based on selected value
-            // remove isSelected marker on the option
+            // add isSelected marker to the option
             this._visibleOptions.forEach(option => {
-                if ( valueArray.indexOf(option.value) > -1 ) {
+                if (valueStrings.indexOf(option.value) > -1 ) {
                     option.isSelected = true;
                 }
             });

--- a/lib/elements/CheckedSelect.js
+++ b/lib/elements/CheckedSelect.js
@@ -33,10 +33,6 @@ class CheckedSelect extends React.Component {
         this.renderMenu = this.renderMenu.bind(this);
         this.getSelectComponent = this.getSelectComponent.bind(this);
         this.getSelectAsyncComponent = this.getSelectAsyncComponent.bind(this);
-
-        this.state = {
-            value: [],
-        };
     }
 
     /**
@@ -99,9 +95,9 @@ class CheckedSelect extends React.Component {
      */
     toggleSelection (selectedValue) {
 
-        let { value } = this.state;
+        let value = this.props.value;
 
-        // check if current state value already contain new item
+        // check if current value already contain new item
         let foundDuplicate = value.find(elem => {
             return elem.value === selectedValue[0].value;
         });
@@ -123,10 +119,7 @@ class CheckedSelect extends React.Component {
             value = value.concat(selectedValue);
         }
 
-        if (this.props.onChange) {
-            this.props.onChange(value);
-        }
-        this.setState({ value: value });
+        this.props.onChange(value);
     }
 
     /**
@@ -147,12 +140,14 @@ class CheckedSelect extends React.Component {
 
     clearVisibleOptions() {
         let visibleOptions = this._visibleOptions;
-        let values = this.state.value;
+        let values = this.props.value.slice();
+        let valueStrings = values.map(valueObject => valueObject.value);
         // remove only visible values
-        visibleOptions.map( visibleOption => {
-            const index = values.indexOf(visibleOption);
+        visibleOptions.forEach(visibleOption => {
+            const index = valueStrings.indexOf(visibleOption.value);
             if (index !== -1) {
                 values.splice(index, 1);
+                valueStrings.splice(index, 1);
             }
         });
         return values
@@ -169,13 +164,11 @@ class CheckedSelect extends React.Component {
     }
 
     setValue (value) {
-        if (this.props.onChange) {
-            if (this.props.simpleValue && value) {
-                value = this.props.multi ?
-                    value.map(i => i[this.props.valueKey]).join(this.props.delimiter) : value[this.props.valueKey];
-            }
-            this.props.onChange(value);
+        if (this.props.simpleValue && value) {
+            value = this.props.multi ?
+                value.map(i => i[this.props.valueKey]).join(this.props.delimiter) : value[this.props.valueKey];
         }
+        this.props.onChange(value);
     }
 
     clearAllOptionsIsSelectedFlags () {
@@ -195,14 +188,12 @@ class CheckedSelect extends React.Component {
             return visibleOption.disabled !== true;
         });
         this.setValue(newValue);
-        this.setState({ value: newValue });
     }
 
     handleClearAll () {
         this.clearVisibleOptionsIsSelected();
         let newValue = this.clearVisibleOptions();
         this.setValue(newValue);
-        this.setState({ value: newValue });
     }
 
     renderMenu (params) {
@@ -287,8 +278,7 @@ class CheckedSelect extends React.Component {
     }
 
     render() {
-        const { value } = this.state;
-        return this.props.async ?  this.getSelectAsyncComponent(value) : this.getSelectComponent(value);
+        return this.props.async ?  this.getSelectAsyncComponent() : this.getSelectComponent();
     }
 }
 

--- a/lib/elements/CheckedSelect.js
+++ b/lib/elements/CheckedSelect.js
@@ -89,18 +89,20 @@ class CheckedSelect extends React.Component {
         return this._visibleOptions;
     }
 
-    componentDidUpdate(prevProps, prevState) {
-        // do below only if value changed
-        let valueArray  = this.props.value.map( val => val.value);
-        // clear all
-        this.clearAllOptionsIsSelectedFlags();
-        // update the flag based on selected value
-        // remove isSelected marker on the option
-        this._visibleOptions.forEach(option => {
-            if ( valueArray.indexOf(option.value) > -1 ) {
-                option.isSelected = true;
-            }
-        });
+    componentDidUpdate(prevProps) {
+        if (this.props.value !== prevProps.value) {
+            // do below only if value changed
+            let valueArray  = this.props.value.map( val => val.value);
+            // clear all
+            this.clearAllOptionsIsSelectedFlags();
+            // update the flag based on selected value
+            // remove isSelected marker on the option
+            this._visibleOptions.forEach(option => {
+                if ( valueArray.indexOf(option.value) > -1 ) {
+                    option.isSelected = true;
+                }
+            });
+        }
     }
 
     /**

--- a/lib/elements/CheckedSelect.js
+++ b/lib/elements/CheckedSelect.js
@@ -89,6 +89,20 @@ class CheckedSelect extends React.Component {
         return this._visibleOptions;
     }
 
+    componentDidUpdate(prevProps, prevState) {
+        // do below only if value changed
+        let valueArray  = this.props.value.map( val => val.value);
+        // clear all
+        this.clearAllOptionsIsSelectedFlags();
+        // update the flag based on selected value
+        // remove isSelected marker on the option
+        this._visibleOptions.forEach(option => {
+            if ( valueArray.indexOf(option.value) > -1 ) {
+                option.isSelected = true;
+            }
+        });
+    }
+
     /**
      * Select option when it is not selected and the other way around.
      * @param selectedValue
@@ -140,12 +154,10 @@ class CheckedSelect extends React.Component {
 
     clearVisibleOptions() {
         const visibleOptionValues = this._visibleOptions
-                .map(optionObject => optionObject.value);
+            .map(optionObject => optionObject.value);
         const values = this.props.value;
         // remove all visible values, keeping only invisible ones
-        const filteredValues = values
-                .filter(valueObject => visibleOptionValues.indexOf(valueObject.value) === -1);
-        return filteredValues;
+        return values.filter(valueObject => visibleOptionValues.indexOf(valueObject.value) === -1);
     }
 
     getResetValue () {
@@ -193,6 +205,7 @@ class CheckedSelect extends React.Component {
 
     renderMenu (params) {
         let props = this.props;
+
         return this._visibleOptions.map((option, i) => {
             let isSelected = params.valueArray && params.valueArray.indexOf(option) > -1;
             let isFocused = option === params.focusedOption;

--- a/lib/elements/CheckedSelect.js
+++ b/lib/elements/CheckedSelect.js
@@ -139,18 +139,13 @@ class CheckedSelect extends React.Component {
     }
 
     clearVisibleOptions() {
-        let visibleOptions = this._visibleOptions;
-        let values = this.props.value.slice();
-        let valueStrings = values.map(valueObject => valueObject.value);
-        // remove only visible values
-        visibleOptions.forEach(visibleOption => {
-            const index = valueStrings.indexOf(visibleOption.value);
-            if (index !== -1) {
-                values.splice(index, 1);
-                valueStrings.splice(index, 1);
-            }
-        });
-        return values
+        const visibleOptionValues = this._visibleOptions
+                .map(optionObject => optionObject.value);
+        const values = this.props.value;
+        // remove all visible values, keeping only invisible ones
+        const filteredValues = values
+                .filter(valueObject => visibleOptionValues.indexOf(valueObject.value) === -1);
+        return filteredValues;
     }
 
     getResetValue () {


### PR DESCRIPTION
The component behaved erratically when changing the selected values externally via the `value=` prop, fixed by removing the current value from internal state and instead the trusting the prop as the one source of truth.