### PR TITLE
Leave invisible options untouched on ‘Add all’

### DIFF
--- a/lib/elements/CheckedSelect.js
+++ b/lib/elements/CheckedSelect.js
@@ -146,12 +146,29 @@ class CheckedSelect extends React.Component {
         return null;
     }
 
+    addVisibleOptionsIsSelected() {
+        let visibleOptions = this._visibleOptions;
+        visibleOptions.forEach(option => option.isSelected = true);
+    }
+
     clearVisibleOptionsIsSelected() {
         let visibleOptions = this._visibleOptions;
         return visibleOptions.map( option => {
             option.isSelected = false;
             return option;
         });
+    }
+
+    addVisibleOptions() {
+        const values = this.props.value;
+        const valueStrings = values.map(valueObject => valueObject.value);
+        // Add currently visible, enabled options to
+        // the already-selected ones
+        const optionsToAdd = this._visibleOptions
+                .filter(optionObject => (
+                    optionObject.disabled !== true
+                    && valueStrings.indexOf(optionObject.value) === -1))
+        return values.concat(optionsToAdd)
     }
 
     clearVisibleOptions() {
@@ -187,21 +204,20 @@ class CheckedSelect extends React.Component {
     }
 
     /**
-     * Select visible and enabled options.
+     * Add all enabled visible options to the selection
      */
     handleAddAll () {
-        // start with clear isSelected for all options
-        this.clearAllOptionsIsSelectedFlags();
-        // only add enabled options
-        let newValue = this._visibleOptions.filter( visibleOption => {
-            return visibleOption.disabled !== true;
-        });
+        this.addVisibleOptionsIsSelected();
+        const newValue = this.addVisibleOptions();
         this.setValue(newValue);
     }
 
+    /**
+     * Clear all visible options from the selection
+     */
     handleClearAll () {
         this.clearVisibleOptionsIsSelected();
-        let newValue = this.clearVisibleOptions();
+        const newValue = this.clearVisibleOptions();
         this.setValue(newValue);
     }
 

--- a/lib/elements/CheckedSelect.js
+++ b/lib/elements/CheckedSelect.js
@@ -153,7 +153,7 @@ class CheckedSelect extends React.Component {
         // the already-selected ones
         const optionsToAdd = this._visibleOptions
                 .filter(optionObject => (
-                    optionObject.disabled !== true
+                    !optionObject.disabled
                     && valueStrings.indexOf(optionObject.value) === -1))
         return values.concat(optionsToAdd)
     }

--- a/lib/elements/CheckedSelect.js
+++ b/lib/elements/CheckedSelect.js
@@ -146,16 +146,6 @@ class CheckedSelect extends React.Component {
         return null;
     }
 
-    addVisibleOptionsIsSelected() {
-        let visibleOptions = this._visibleOptions;
-        visibleOptions.forEach(option => option.isSelected = true);
-    }
-
-    clearVisibleOptionsIsSelected() {
-        let visibleOptions = this._visibleOptions;
-        visibleOptions.forEach(option => option.isSelected = false);
-    }
-
     addVisibleOptions() {
         const values = this.props.value;
         const valueStrings = values.map(valueObject => valueObject.value);
@@ -200,11 +190,16 @@ class CheckedSelect extends React.Component {
         });
     }
 
+    setVisibleOptionsIsSelectedFlags(newState) {
+        let visibleOptions = this._visibleOptions;
+        visibleOptions.forEach(option => option.isSelected = newState);
+    }
+
     /**
      * Add all enabled visible options to the selection
      */
     handleAddAll () {
-        this.addVisibleOptionsIsSelected();
+        this.setVisibleOptionsIsSelectedFlags(true);
         const newValue = this.addVisibleOptions();
         this.setValue(newValue);
     }
@@ -213,7 +208,7 @@ class CheckedSelect extends React.Component {
      * Clear all visible options from the selection
      */
     handleClearAll () {
-        this.clearVisibleOptionsIsSelected();
+        this.setVisibleOptionsIsSelectedFlags(false);
         const newValue = this.clearVisibleOptions();
         this.setValue(newValue);
     }

--- a/lib/elements/CheckedSelect.js
+++ b/lib/elements/CheckedSelect.js
@@ -153,10 +153,7 @@ class CheckedSelect extends React.Component {
 
     clearVisibleOptionsIsSelected() {
         let visibleOptions = this._visibleOptions;
-        return visibleOptions.map( option => {
-            option.isSelected = false;
-            return option;
-        });
+        visibleOptions.forEach(option => option.isSelected = false);
     }
 
     addVisibleOptions() {


### PR DESCRIPTION
To be consistent with the 'Clear all' button, the 'Add all' button
should only add all currently visible options to the selection.
Invisible (i.e. filtered or currently nonexistent) options should be
left as-is, selected or unselected. This is a fix for issue #4.