### PR TITLE
Remove accidentally broken binding

### DIFF
--- a/lib/elements/CheckedSelect.js
+++ b/lib/elements/CheckedSelect.js
@@ -24,7 +24,6 @@ class CheckedSelect extends React.Component {
         this.handleFilterOptions = this.handleFilterOptions.bind(this);
         this.toggleSelection = this.toggleSelection.bind(this);
         this.clearAllOptionsIsSelectedFlags = this.clearAllOptionsIsSelectedFlags.bind(this);
-        this.clearVisibleOptionsIsSelected = this.clearVisibleOptionsIsSelected.bind(this);
         this.clearVisibleOptions = this.clearVisibleOptions.bind(this);
         this.getResetValue = this.getResetValue.bind(this);
         this.setValue = this.setValue.bind(this);


### PR DESCRIPTION
In cleaning up the implementation of a bugfix, I accidentally left in a
binding that depends on a method that has been renamed, causing the
component to crash with an exception. The method is only used by method
reference and not passed around as a callback, so the binding can safely
be removed.