### PR TITLE
Consistently respect the valueKey prop

### DIFF
--- a/lib/elements/CheckedSelect.js
+++ b/lib/elements/CheckedSelect.js
@@ -92,13 +92,13 @@ class CheckedSelect extends React.Component {
     componentWillReceiveProps(nextProps) {
         if (this.props.value !== nextProps.value) {
             // do below only if value changed
-            let valueStrings  = nextProps.value.map(val => val.value);
+            let valueStrings  = nextProps.value.map(val => val[nextProps.valueKey]);
             // clear all
             this.clearAllOptionsIsSelectedFlags();
             // update the flag based on selected value
             // add isSelected marker to the option
             this._visibleOptions.forEach(option => {
-                if (valueStrings.indexOf(option.value) > -1 ) {
+                if (valueStrings.indexOf(option[this.props.valueKey]) > -1 ) {
                     option.isSelected = true;
                 }
             });
@@ -115,18 +115,18 @@ class CheckedSelect extends React.Component {
 
         // check if current value already contain new item
         let foundDuplicate = value.find(elem => {
-            return elem.value === selectedValue[0].value;
+            return elem[this.props.valueKey] === selectedValue[0][this.props.valueKey];
         });
 
         // remove item if it exists
         if (foundDuplicate) {
             value = value.filter( val => {
-                return foundDuplicate.value !== val.value;
+                return foundDuplicate[this.props.valueKey] !== val[this.props.valueKey];
             });
 
             // remove isSelected marker on the option
             this._visibleOptions.map( option => {
-                if (foundDuplicate.value === option.value) {
+                if (foundDuplicate[this.props.valueKey] === option[this.props.valueKey]) {
                     option.isSelected = false;
                 }
                 return option;
@@ -148,22 +148,22 @@ class CheckedSelect extends React.Component {
 
     addVisibleOptions() {
         const values = this.props.value;
-        const valueStrings = values.map(valueObject => valueObject.value);
+        const valueStrings = values.map(valueObject => valueObject[this.props.valueKey]);
         // Add currently visible, enabled options to
         // the already-selected ones
         const optionsToAdd = this._visibleOptions
                 .filter(optionObject => (
                     !optionObject.disabled
-                    && valueStrings.indexOf(optionObject.value) === -1))
+                    && valueStrings.indexOf(optionObject[this.props.valueKey]) === -1))
         return values.concat(optionsToAdd)
     }
 
     clearVisibleOptions() {
         const visibleOptionValues = this._visibleOptions
-            .map(optionObject => optionObject.value);
+            .map(optionObject => optionObject[this.props.valueKey]);
         const values = this.props.value;
         // remove all visible values, keeping only invisible ones
-        return values.filter(valueObject => visibleOptionValues.indexOf(valueObject.value) === -1);
+        return values.filter(valueObject => visibleOptionValues.indexOf(valueObject[this.props.valueKey]) === -1);
     }
 
     getResetValue () {


### PR DESCRIPTION
The value key to be used when handling option objects was hard-coded to
`'value'` in several places; consistently using the property passed to the
component makes it configurable again.