### PR TITLE
Maintain the search string when options are clicked

### DIFF
--- a/lib/elements/CheckedSelect.js
+++ b/lib/elements/CheckedSelect.js
@@ -263,6 +263,7 @@ class CheckedSelect extends React.Component {
                     onChange={this.toggleSelection}
                     clearRenderer={this.renderClearButton}
                     closeOnSelect={false}
+                    onSelectResetsInput={false}
                     disabled={this.props.disabled}
                     multi
                     menuRenderer={this.renderMenu}
@@ -283,6 +284,7 @@ class CheckedSelect extends React.Component {
                     onChange={this.toggleSelection}
                     clearRenderer={this.renderClearButton}
                     closeOnSelect={false}
+                    onSelectResetsInput={false}
                     disabled={this.props.disabled}
                     multi
                     menuRenderer={this.renderMenu}


### PR DESCRIPTION
This fixes the usability concern tracked in issue #6; it allows users to
(de)select multiple individual options from a filtered list, further optimising
usability for long lists of options.