### PR TITLE
Extract sync/async decorator in unit tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -6,39 +6,32 @@ import { mount, render } from 'enzyme';
 import sinon from 'sinon';
 
 function withSyncAndAsync(specFunction) {
-    const asyncOptions = [
-        {
-            asyncValue: false,
-            makeOpts: options => options,
-            makeLoadOpts: options => undefined
-        },
-        {
-            asyncValue: true,
-            makeOpts: options => undefined,
-            makeLoadOpts: options => (() => Promise.resolve(
+    describe('with async={ false }', () => {
+        specFunction(options => ({
+            async: false,
+            options: options,
+        }));
+    });
+    describe('with async={ true }', () => {
+        specFunction(options => ({
+            async: true,
+            loadOptions: () => Promise.resolve(
                 { options, complete: true }
-            ))
-         },
-    ];
-    asyncOptions.forEach(({ asyncValue, makeOpts, makeLoadOpts }) => {
-        describe(`with async={ ${ asyncValue } }`, () => {
-            specFunction({ asyncValue, makeOpts, makeLoadOpts });
-        });
+            )
+        }));
     });
 };
 
 describe('CheckedSelect', () => {
     const getMinimalOptionsProp = () => [{ label: 'one', value: 1 }, { label: 'two', value: 2 }];
-    withSyncAndAsync(({ asyncValue, makeOpts, makeLoadOpts }) => {
+    withSyncAndAsync(makeAsyncDependentProps => {
         it('leaves selection unchanged if backspace is pressed in an empty search box', () => {
             // given
             const options = getMinimalOptionsProp();
             const selection = [{ value: 2 }];
             const changeHandler = sinon.spy();
             const wrapper = mount(<CheckedSelect
-                async={ asyncValue }
-                options={ makeOpts(options) }
-                loadOptions={ makeLoadOpts(options) }
+                { ...makeAsyncDependentProps(options) }
                 value={ selection }
                 onChange={ changeHandler }
             />);
@@ -53,16 +46,14 @@ describe('CheckedSelect', () => {
         });
     });
 
-    withSyncAndAsync(({ asyncValue, makeOpts, makeLoadOpts }) => {
+    withSyncAndAsync(makeAsyncDependentProps => {
         it('displays the placeholder text once if nothing is selected', () => {
             // given
             const options = getMinimalOptionsProp();
             const placeholderText = 'Some number';
             //when
             const wrapper = render(<CheckedSelect
-                async={ asyncValue }
-                options={ makeOpts(options) }
-                loadOptions={ makeLoadOpts(options) }
+                { ...makeAsyncDependentProps(options) }
                 onChange={ sinon.stub() }
                 value={ [] }
                 placeholder={ placeholderText }
@@ -72,16 +63,14 @@ describe('CheckedSelect', () => {
         });
     });
 
-    withSyncAndAsync(({ asyncValue, makeOpts, makeLoadOpts }) => {
+    withSyncAndAsync(makeAsyncDependentProps => {
         it('displays the placeholder text once if values are selected', () => {
             // given
             const options = getMinimalOptionsProp();
             const placeholderText = 'Some number';
             // when
             const wrapper = render(<CheckedSelect
-                async={ asyncValue }
-                options={ makeOpts(options) }
-                loadOptions={ makeLoadOpts(options) }
+                { ...makeAsyncDependentProps(options) }
                 onChange={ sinon.stub() }
                 value={ [{ value: 1 }, { value: 2 }] }
                 placeholder={ placeholderText }
@@ -91,14 +80,12 @@ describe('CheckedSelect', () => {
         });
     });
 
-    withSyncAndAsync(({ asyncValue, makeOpts, makeLoadOpts }) => {
+    withSyncAndAsync(makeAsyncDependentProps => {
         it('does not display the placeholder text while typing a search string for additional values', done => {
             const options = getMinimalOptionsProp();
             const placeholderText = 'Some number';
             const wrapper = mount(<CheckedSelect
-                async={ asyncValue }
-                options={ makeOpts(options) }
-                loadOptions={ makeLoadOpts(options) }
+                { ...makeAsyncDependentProps(options) }
                 onChange={ sinon.stub() }
                 value={ [{ value: 1 }] }
                 placeholder={ placeholderText }

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 import { mount, render } from 'enzyme';
 import sinon from 'sinon';
 
-describe('CheckedSelect behaviour independent of synchronicity', () => {
+function withSyncAndAsync(specFunction) {
     const asyncOptions = [
         {
             asyncValue: false,
@@ -22,82 +22,94 @@ describe('CheckedSelect behaviour independent of synchronicity', () => {
     ];
     asyncOptions.forEach(({ asyncValue, makeOpts, makeLoadOpts }) => {
         describe(`with async={ ${ asyncValue } }`, () => {
-            const getMinimalOptionsProp = () => [{ label: 'one', value: 1 }, { label: 'two', value: 2 }];
-            it('leaves selection unchanged if backspace is pressed in an empty search box', () => {
-                // given
-                const options = getMinimalOptionsProp();
-                const selection = [{ value: 2 }];
-                const changeHandler = sinon.spy();
-                const wrapper = mount(<CheckedSelect
-                    async={ asyncValue }
-                    options={ makeOpts(options) }
-                    loadOptions={ makeLoadOpts(options) }
-                    value={ selection }
-                    onChange={ changeHandler }
-                />);
-                // when
-                const key = { key: 'Backspace', keyCode: 8, which: 8 };
-                const searchBox = wrapper.find('input');
-                searchBox.simulate('keydown', key);
-                searchBox.simulate('keypress', key);
-                searchBox.simulate('keyup', key);
-                // then
-                assert.isTrue(changeHandler.notCalled);
-            });
+            specFunction({ asyncValue, makeOpts, makeLoadOpts });
+        });
+    });
+};
 
-            it('displays the placeholder text once if nothing is selected', () => {
-                // given
-                const options = getMinimalOptionsProp();
-                const placeholderText = 'Some number';
-                //when
-                const wrapper = render(<CheckedSelect
-                    async={ asyncValue }
-                    options={ makeOpts(options) }
-                    loadOptions={ makeLoadOpts(options) }
-                    onChange={ sinon.stub() }
-                    value={ [] }
-                    placeholder={ placeholderText }
-                />);
-                // then
-                assert.equal(wrapper.text(), placeholderText);
-            });
+describe('CheckedSelect', () => {
+    const getMinimalOptionsProp = () => [{ label: 'one', value: 1 }, { label: 'two', value: 2 }];
+    withSyncAndAsync(({ asyncValue, makeOpts, makeLoadOpts }) => {
+        it('leaves selection unchanged if backspace is pressed in an empty search box', () => {
+            // given
+            const options = getMinimalOptionsProp();
+            const selection = [{ value: 2 }];
+            const changeHandler = sinon.spy();
+            const wrapper = mount(<CheckedSelect
+                async={ asyncValue }
+                options={ makeOpts(options) }
+                loadOptions={ makeLoadOpts(options) }
+                value={ selection }
+                onChange={ changeHandler }
+            />);
+            // when
+            const key = { key: 'Backspace', keyCode: 8, which: 8 };
+            const searchBox = wrapper.find('input');
+            searchBox.simulate('keydown', key);
+            searchBox.simulate('keypress', key);
+            searchBox.simulate('keyup', key);
+            // then
+            assert.isTrue(changeHandler.notCalled);
+        });
+    });
 
-            it('displays the placeholder text once if values are selected', () => {
-                // given
-                const options = getMinimalOptionsProp();
-                const placeholderText = 'Some number';
-                // when
-                const wrapper = render(<CheckedSelect
-                    async={ asyncValue }
-                    options={ makeOpts(options) }
-                    loadOptions={ makeLoadOpts(options) }
-                    onChange={ sinon.stub() }
-                    value={ [{ value: 1 }, { value: 2 }] }
-                    placeholder={ placeholderText }
-                />);
-                // then
-                assert.equal(wrapper.text(), placeholderText);
-            });
+    withSyncAndAsync(({ asyncValue, makeOpts, makeLoadOpts }) => {
+        it('displays the placeholder text once if nothing is selected', () => {
+            // given
+            const options = getMinimalOptionsProp();
+            const placeholderText = 'Some number';
+            //when
+            const wrapper = render(<CheckedSelect
+                async={ asyncValue }
+                options={ makeOpts(options) }
+                loadOptions={ makeLoadOpts(options) }
+                onChange={ sinon.stub() }
+                value={ [] }
+                placeholder={ placeholderText }
+            />);
+            // then
+            assert.equal(wrapper.text(), placeholderText);
+        });
+    });
 
-            it('does not display the placeholder text while typing a search string for additional values', done => {
-                const options = getMinimalOptionsProp();
-                const placeholderText = 'Some number';
-                const wrapper = mount(<CheckedSelect
-                    async={ asyncValue }
-                    options={ makeOpts(options) }
-                    loadOptions={ makeLoadOpts(options) }
-                    onChange={ sinon.stub() }
-                    value={ [{ value: 1 }] }
-                    placeholder={ placeholderText }
-                />);
-                // when
-                const searchBox = wrapper.find('input');
-                searchBox.simulate('change', { target: { value: 'tw' } });
-                // then, after allowing any async options to be returned
-                setImmediate(() => {
-                    assert.notInclude(wrapper.text(), placeholderText);
-                    done();
-                });
+    withSyncAndAsync(({ asyncValue, makeOpts, makeLoadOpts }) => {
+        it('displays the placeholder text once if values are selected', () => {
+            // given
+            const options = getMinimalOptionsProp();
+            const placeholderText = 'Some number';
+            // when
+            const wrapper = render(<CheckedSelect
+                async={ asyncValue }
+                options={ makeOpts(options) }
+                loadOptions={ makeLoadOpts(options) }
+                onChange={ sinon.stub() }
+                value={ [{ value: 1 }, { value: 2 }] }
+                placeholder={ placeholderText }
+            />);
+            // then
+            assert.equal(wrapper.text(), placeholderText);
+        });
+    });
+
+    withSyncAndAsync(({ asyncValue, makeOpts, makeLoadOpts }) => {
+        it('does not display the placeholder text while typing a search string for additional values', done => {
+            const options = getMinimalOptionsProp();
+            const placeholderText = 'Some number';
+            const wrapper = mount(<CheckedSelect
+                async={ asyncValue }
+                options={ makeOpts(options) }
+                loadOptions={ makeLoadOpts(options) }
+                onChange={ sinon.stub() }
+                value={ [{ value: 1 }] }
+                placeholder={ placeholderText }
+            />);
+            // when
+            const searchBox = wrapper.find('input');
+            searchBox.simulate('change', { target: { value: 'tw' } });
+            // then, after allowing any async options to be returned
+            setImmediate(() => {
+                assert.notInclude(wrapper.text(), placeholderText);
+                done();
             });
         });
     });


### PR DESCRIPTION
Moving this parametrisation logic to a separate function should make the
tests more readable, by putting the parameters closer to the actual test
and reducing the level of nesting.

It has the added effect of changing the test output to look something like
this:
![Console screenshot that shows each test twice, prefixed with a line that says either with ‘async={ false }’ or with ‘async={ true }’](https://user-images.githubusercontent.com/4929431/40707341-b517eae6-63f0-11e8-8138-ab9d4df95bcb.png)

Listing the two variants of the same test adjacently, rather than grouped with
all other (a)synchronous versions of tests. It might be a matter of preference,
but I think that this version could scale better if the the number of tests
grows.